### PR TITLE
Remove unused LIBS

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -15,7 +15,7 @@ TARGET = ukui-notebook
 TEMPLATE = app
 
 LIBS  +=  -lpthread
-LIBS  +=  -lX11 -lXrandr -lXinerama -lXi -lXcursor
+LIBS  +=  -lX11 -lXi
 
 PKGCONFIG += gsettings-qt
 


### PR DESCRIPTION
The resulting package doesn't link to any of these libs, according to Arch namcap:

```
ukui-notebook W: Dependency included and not needed ('libxcursor')
ukui-notebook W: Dependency included and not needed ('libxinerama')
ukui-notebook W: Dependency included and not needed ('libxrandr')
```

Verified that it built fine here without any of the these libs installed.