### PR TITLE
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ukui-notebook (3.1.1-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sun, 24 Apr 2022 09:14:25 -0000
+
 ukui-notebook (3.1.1-1) unstable; urgency=medium
 
   * Initial release. (Closes: 1005182)

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/ukui/ukui-notebook/issues
+Bug-Submit: https://github.com/ukui/ukui-notebook/issues/new
+Repository: https://github.com/ukui/ukui-notebook.git
+Repository-Browse: https://github.com/ukui/ukui-notebook


### PR DESCRIPTION

Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/bd4369d7-d8cf-44e6-9e08-c098ae29db50/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/bd4369d7-d8cf-44e6-9e08-c098ae29db50/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/bd4369d7-d8cf-44e6-9e08-c098ae29db50/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/ukui-notebook/bd4369d7-d8cf-44e6-9e08-c098ae29db50.